### PR TITLE
Config to deploy in kubernetes using gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ hh-test-deploy:
   environment:
     name: hh/test
     deployment_tier: testing
-    url: http://hh-rke-wp-webadmin-99-worker-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
+    url: http://hh-rke-wp-webadmin-99-master-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
 
 hx-prod-deploy:
   extends: .kubernetes-deploy
@@ -90,7 +90,7 @@ hx-prod-deploy:
   environment:
     name: hx/prod
     deployment_tier: production
-    url: http://hx-rke-wp-webadmin-78-worker-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
+    url: http://hx-rke-wp-webadmin-78-master-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
 
 hh-prod-deploy:
   extends: .kubernetes-deploy
@@ -103,4 +103,4 @@ hh-prod-deploy:
   environment:
     name: hh/prod
     deployment_tier: production
-    url: http://hh-rke-wp-webadmin-102-worker-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
+    url: http://hh-rke-wp-webadmin-102-master-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,106 @@
+image: docker:latest
+services:
+  - docker:stable-dind
+variables:
+  DOCKER_TLS_CERTDIR: ""
+stages:
+  - build-jar
+  - build-docker-image
+  - kubernetes-deploy
+
+maven-build:
+  image: maven:3.6-jdk-11
+  stage: build-jar
+  script:
+    - mvn package -B -s settings.xml -P registry-k8s
+    - POM_VERSION=$(mvn -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive exec:exec -q)
+    - echo "IMAGE_TAG=$POM_VERSION-$CI_COMMIT_SHORT_SHA" > build.env
+  artifacts:
+    paths:
+      - target/*.war
+    reports:
+      dotenv: build.env
+  when: manual
+
+docker-build:
+  stage: build-docker-image
+  needs: [ maven-build ]
+  before_script:
+    - unset DOCKER_HOST
+    - unset DOCKER_AUTH_CONFIG
+    - docker system prune -af
+  script:
+    - echo "$CI_DOCKER_HUB_PASSWORD" | docker login -u $CI_DOCKER_HUB_USER --password-stdin
+    - echo "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
+    - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" --no-cache .
+    - docker image ls
+    - docker logout
+    - echo "$CI_REGISTRY_PASSWORD" | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
+    - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
+    - docker rmi "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
+    - docker logout $CI_REGISTRY
+
+.kubernetes-deploy:
+  stage: kubernetes-deploy
+  image: alpine
+  before_script:
+    - apk add --no-cache curl git
+    - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+    - chmod +x ./kubectl
+    - mv ./kubectl /usr/local/bin/kubectl
+    - git clone https://k8s-config-token:$K8S_CONFIG_TOKEN@gitlab.ebi.ac.uk/intact-ci/k8s-config
+    - mkdir ~/.kube
+    - cp k8s-config/config ~/.kube/
+  script:
+    - kubectl config get-contexts
+    - kubectl config use-context $KUBE_CONTEXT
+    - kubectl create secret docker-registry gitlab-registry --docker-server=$CI_REGISTRY --docker-username=$CI_REGISTRY_USER --docker-password=$CI_JOB_TOKEN --docker-email=$GITLAB_USER_EMAIL --dry-run=client -o yaml | kubectl apply -f -
+    - kubectl get secrets gitlab-registry -o yaml
+    - echo "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
+    - sed -i -e "s|<IMAGE_TAG>|$CI_REGISTRY_IMAGE:$IMAGE_TAG|g" k8s-deploy-config/k8s_deploy.yml
+    - sed -i -e "s|<PROXY_HOST>|$PROXY_HOST|g" k8s-deploy-config/k8s_deploy.yml
+    - sed -i -e "s|<NFS_SERVER>|$NFS_SERVER|g" k8s-deploy-config/k8s_deploy.yml
+    - sed -i -e "s|<NFS_PATH>|$NFS_PATH|g" k8s-deploy-config/k8s_deploy.yml
+    - kubectl apply -f k8s-deploy-config/k8s_deploy.yml
+    - kubectl rollout restart deployment/psicquic-registry-deployment
+    - kubectl get nodes
+  when: manual
+
+hh-test-deploy:
+  extends: .kubernetes-deploy
+  needs: [ maven-build, docker-build ]
+  variables:
+    PROXY_HOST: hh-wwwcache.ebi.ac.uk
+    NFS_SERVER: hh-isi-srv-vlan1496.ebi.ac.uk
+    NFS_PATH: /ifs/public/rw/intact
+    KUBE_CONTEXT: hh-intact-test
+  environment:
+    name: hh/test
+    deployment_tier: testing
+    url: http://hh-rke-wp-webadmin-99-worker-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
+
+hx-prod-deploy:
+  extends: .kubernetes-deploy
+  needs: [ maven-build, docker-build ]
+  variables:
+    PROXY_HOST: hx-wwwcache.ebi.ac.uk
+    NFS_SERVER: hx-isi-srv-vlan157.ebi.ac.uk
+    NFS_PATH: /ifs/public-r/rw/intact
+    KUBE_CONTEXT: hx-intact-prod
+  environment:
+    name: hx/prod
+    deployment_tier: production
+    url: http://hx-rke-wp-webadmin-78-worker-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
+
+hh-prod-deploy:
+  extends: .kubernetes-deploy
+  needs: [ maven-build, docker-build ]
+  variables:
+    PROXY_HOST: hh-wwwcache.ebi.ac.uk
+    NFS_SERVER: hh-isi-srv-vlan1496.ebi.ac.uk
+    NFS_PATH: /ifs/public/rw/intact
+    KUBE_CONTEXT: hh-intact-prod
+  environment:
+    name: hh/prod
+    deployment_tier: production
+    url: http://hh-rke-wp-webadmin-102-worker-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM tomcat:9-jdk11
+
+ENV USER=docker
+### psi_ia user
+ENV UID=2799
+### pst_pub group
+ENV GID=1137
+RUN addgroup --gid "$GID" "$USER" \
+  && adduser \
+  --disabled-password \
+  --gecos "" \
+  --home "$(pwd)" \
+  --ingroup "$USER" \
+  --no-create-home \
+  --uid "$UID" \
+  "$USER"
+
+ADD /target/psicquic-registry.war "/usr/local/tomcat/webapps/psicquic#registry.war"
+RUN cp -r webapps.dist/ROOT webapps/
+RUN cp -r webapps.dist/manager webapps/
+
+RUN chown -R $USER:$USER /usr/local/tomcat
+
+CMD ["catalina.sh", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN addgroup --gid "$GID" "$USER" \
   --uid "$UID" \
   "$USER"
 
-ADD /target/psicquic-registry.war "/usr/local/tomcat/webapps/psicquic#registry.war"
+ADD /target/psicquic-registry.war "/usr/local/tomcat/webapps/Tools#webservices#psicquic#registry
 RUN cp -r webapps.dist/ROOT webapps/
 RUN cp -r webapps.dist/manager webapps/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN addgroup --gid "$GID" "$USER" \
   --uid "$UID" \
   "$USER"
 
-ADD /target/psicquic-registry.war "/usr/local/tomcat/webapps/Tools#webservices#psicquic#registry
+ADD /target/psicquic-registry.war "/usr/local/tomcat/webapps/Tools#webservices#psicquic#registry.war"
 RUN cp -r webapps.dist/ROOT webapps/
 RUN cp -r webapps.dist/manager webapps/
 

--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ Then, browse to:
 ```
 http://localhost:9091/psicquic/registry/registry?action=STATUS
 ```
+
+## Update certificate
+TODO: add details here

--- a/k8s-deploy-config/k8s_deploy.yml
+++ b/k8s-deploy-config/k8s_deploy.yml
@@ -1,0 +1,109 @@
+# Specifies what version of K8s you want to use
+apiVersion: v1
+# A service is used to expose your Deployment to the external access
+kind: Service
+metadata:
+  name: psicquic-registry-service
+spec:
+  ports:
+    - port: 31239
+      protocol: TCP
+      # The port which will be externally exposed. Must be in the range [30000, 32767].
+      nodePort: 31239
+      # The port on your Deployment which it will expose
+      targetPort: 8080
+  selector:
+    # Selects the disease-portal-client Deployment to attach the Service to
+    app: psicquic-registry
+    # Tell K8s this wants to expose an external port
+  type: NodePort
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: psicquic-registry-deployment
+spec:
+  selector:
+    matchLabels:
+      app: psicquic-registry
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: psicquic-registry
+    spec:
+      securityContext:
+        runAsUser: 2799
+        runAsGroup: 1137
+      terminationGracePeriodSeconds: 10
+      restartPolicy: Always
+      containers:
+        - name: psicquic-registry
+          # Pull the image which contains psicquic-registry webservice and the built assets from EBI's dockerhub
+          image: <IMAGE_TAG>
+          ports:
+            # We are using psicquic-registry webservice config which serves on port 8080
+            - containerPort: 8080
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "/bin/sh"
+                  - "-c"
+                  - "if [ ! -d /usr/local/tomcat/conf/tomcat-users.xml ] ; then cp /tmp/tomcat-users.xml /usr/local/tomcat/conf/tomcat-users.xml ; fi ; \
+                     if [ ! -d /usr/local/tomcat/webapps/manager/META-INF/context.xml ] ; then cp /tmp/manager-context.xml /usr/local/tomcat/webapps/manager/META-INF/context.xml ; fi ;"
+          volumeMounts:
+            - name: nfs-rw-volume
+              mountPath: /nfs/public/rw/intact
+            - name: tomcat-config
+              mountPath: /tmp/tomcat-users.xml
+              subPath: tomcat-users.xml
+            - name: tomcat-config
+              mountPath: /tmp/manager-context.xml
+              subPath: manager-context.xml
+          env:
+            - name: KEYSTORE_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: keystore-config
+                  key: keystorePath
+            - name: KEYSTORE_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: keystore-config
+                  key: keystorePassword
+            - name: CATALINA_OPTS
+              value: "-Djavax.net.ssl.trustStore=$(KEYSTORE_PATH) -Djavax.net.ssl.keyStorePassword=$(KEYSTORE_PASSWORD)"
+            - name: http_proxy
+              value: "http://<PROXY_HOST>:3128"
+            - name: https_proxy
+              value: "http://<PROXY_HOST>:3128"
+            - name: JAVA_OPTS
+              value: "-Dhttp.proxyHost=<PROXY_HOST> -Dhttp.proxyPort=3128 -Dhttps.proxyHost=<PROXY_HOST> -Dhttps.proxyPort=3128"
+      volumes:
+        - name: nfs-rw-volume
+          nfs:
+            # URL for the NFS server
+            server: <NFS_SERVER>
+            path: <NFS_PATH>
+        - name: tomcat-config
+          configMap:
+            name: tomcat-config
+      imagePullSecrets:
+        # Provided by GitLab, this allows K8s to connect to dockerhub.ebi.ac.uk
+        - name: gitlab-registry

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </properties>
 
     <build>
-        <finalName>${project.artifactId}-${project.version}</finalName>
+        <finalName>${project.artifactId}</finalName>
 
         <resources>
             <resource>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <profiles>
+        <profile>
+            <id>registry-k8s</id>
+            <properties>
+                <psicquic.registry.url>file:///nfs/public/rw/intact/psicquic/registry/psicquic-registry.xml</psicquic.registry.url>
+            </properties>
+        </profile>
+    </profiles>
+</settings>


### PR DESCRIPTION
All the config needed for Kubernetes and Gitlab.

Test
- http://hh-rke-wp-webadmin-99-master-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
- http://hh-rke-wp-webadmin-99-worker-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
- http://hh-rke-wp-webadmin-99-worker-2.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
- http://hh-rke-wp-webadmin-99-worker-3.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS

Prod
- http://hh-rke-wp-webadmin-102-master-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
- http://hh-rke-wp-webadmin-102-worker-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
- http://hh-rke-wp-webadmin-102-worker-2.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
- http://hh-rke-wp-webadmin-102-worker-3.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS

Prod fallback
- http://hx-rke-wp-webadmin-78-master-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
- http://hx-rke-wp-webadmin-78-worker-1.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
- http://hx-rke-wp-webadmin-78-worker-2.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS
- http://hx-rke-wp-webadmin-78-worker-3.caas.ebi.ac.uk:31239/psicquic/registry/registry?action=STATUS

Fairly similar to the other PSICQUIC PRs, with proxies, access to NFS drive and access to the keystore.